### PR TITLE
.NET Core compatability

### DIFF
--- a/src/EventStore.Reactive/EventStore.Reactive/project.json
+++ b/src/EventStore.Reactive/EventStore.Reactive/project.json
@@ -1,0 +1,13 @@
+{
+    "version": "1.0.0-*",
+    "dependencies": {
+        "Newtonsoft.Json": "9.0.1",
+        "EventStore.ClientAPI.NetCore": "0.0.1-alpha",
+        "System.Reactive.Core": "3.1.1"
+    },
+    "frameworks": {
+        "netstandard1.6": {
+            "NETStandard.Library": "1.6.0"
+        }
+    }
+}

--- a/src/EventStore.Reactive/global.json
+++ b/src/EventStore.Reactive/global.json
@@ -1,0 +1,8 @@
+{
+    "projects": [
+        "EventStore.Reactive"
+    ],
+    "sdk": {
+        "version": "1.0.0-preview2-003131"
+    }
+}


### PR DESCRIPTION
This PR should add compatibility to .NET core. I've upgraded deps for Reactive Extensions, Newtonsoft.Json and the EventStore C# Wrapper to .NET core and it builds with 2 deprecation warnings.

Still needs to be smoke tested but it should work.